### PR TITLE
Chemicompiler Fix

### DIFF
--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -710,9 +710,6 @@ datum/chemicompiler_core/stationaryCore
 	attackby(var/obj/item/reagent_containers/glass/B as obj, var/mob/user as mob)
 		if (!istype(B, /obj/item/reagent_containers/glass))
 			return
-		if (status & BROKEN || !powered())
-			boutput( user, "<span style='color:red'>You can't seem to power it on!</span>" )
-			return
 		if (isrobot(user)) return attack_ai(user)
 		return attack_hand(user)
 

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -666,6 +666,7 @@ datum/chemicompiler_core/stationaryCore
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "chemicompiler_st_off"
 	mats = 15
+	flags = NOSPLASH
 	var/datum/chemicompiler_executor/executor
 	var/datum/light/light
 
@@ -705,6 +706,15 @@ datum/chemicompiler_core/stationaryCore
 		executor.panel()
 		onclose(usr, "chemicompiler")
 		return
+	
+	attackby(var/obj/item/reagent_containers/glass/B as obj, var/mob/user as mob)
+		if (!istype(B, /obj/item/reagent_containers/glass))
+			return
+		if (status & BROKEN || !powered())
+			boutput( user, "<span style='color:red'>You can't seem to power it on!</span>" )
+			return
+		if (isrobot(user)) return attack_ai(user)
+		return attack_hand(user)
 
 	power_change()
 

--- a/code/modules/chemistry/chemicompiler_core.dm
+++ b/code/modules/chemistry/chemicompiler_core.dm
@@ -742,7 +742,7 @@
 		var/element_temp = R.total_temperature < temp ? 9000 : 0							//Sidewinder7: Smart heating system. Allows the CC to heat at full power for more of the duration, and prevents reheating of reacted elements.
 		var/max_temp_change = abs(R.total_temperature - temp)
 		var/next_temp_change = min(max((abs(R.total_temperature - element_temp) / 35), 1), 15)	// Formula used by temperature_reagents() to determine how much to change the temp
-		if(next_temp_change > max_temp_change)													// Check if this tick will cause the temperature to overshoot if heated/cooled at full power
+		if(next_temp_change >= max_temp_change)													// Check if this tick will cause the temperature to overshoot if heated/cooled at full power. Use >= to prevent reheating in the case the values line up perfectly
 			var/element_temp_offset = max_temp_change * 35										// Compute the exact exposure temperature to reach the target
 			element_temp = R.total_temperature + element_temp_offset * (temp > R.total_temperature ? 1 : -1)
 			heating_in_progress = 0


### PR DESCRIPTION
The Chemicompiler heater functionality has an annoying quirk where it will heat up to the reagents, which will then react, resetting their temperature, and forcing you to wait for it to heat all the way back up. In addition, due to the way the temperature loop is controlled, the CC always heat to 3 degrees below where you specified. This patch changes the heating algorithm to be more consistent. It allows the CC heater to run at full power until the reagent is almost completely heated(or cooled), then turns down the temperature to ensure that the exact target temperature is reached. This also prevents the CC from reheating the already-reacted product, drastically reducing the time needed to heat stuff.
Also allows you to open the Chemicompiler with a beaker in your hand instead of dumping it on top of it.