### PR TITLE
Pathology changes, fixes and additions

### DIFF
--- a/browserassets/css/pathoui.css
+++ b/browserassets/css/pathoui.css
@@ -86,7 +86,7 @@ div {
 #analyzeResults {
 	padding-top:2px;
 	width:300px;
-	height:175px;
+	height:220px;
 	display:inline-block;
 }
 /*Splicer components*/
@@ -194,6 +194,14 @@ div {
 	overflow-x:scroll;
 	overflow-y:hidden;
 	white-space:nowrap;
+}
+
+.tf-med-long {
+	width:180px;
+	height:25px;
+	padding:3px;
+	float:right;
+	text-align:center;
 }
 
 .tf-med {

--- a/browserassets/css/pathoui.css
+++ b/browserassets/css/pathoui.css
@@ -85,8 +85,8 @@ div {
 }
 #analyzeResults {
 	padding-top:2px;
-	width:300px;
-	height:220px;
+	width:400px;
+	height:170px;
 	display:inline-block;
 }
 /*Splicer components*/
@@ -197,13 +197,23 @@ div {
 }
 
 .tf-med-long {
-	width:170px;
+	width:75px;
 	height:25px;
-	padding:3px;
 	text-align:center;
 	margin:1px;
-	margin-right:10px;
 	padding:3px;
+	font-weight:bold;
+	cursor:default;
+}
+
+.tf-med-narrow {
+	width:27px;
+	height:25px;
+	text-align:center;
+	margin:1px;
+	padding:3px;
+	font-weight:bold;
+	cursor:default;
 }
 
 .tf-med {

--- a/browserassets/css/pathoui.css
+++ b/browserassets/css/pathoui.css
@@ -197,11 +197,13 @@ div {
 }
 
 .tf-med-long {
-	width:180px;
+	width:170px;
 	height:25px;
 	padding:3px;
-	float:right;
 	text-align:center;
+	margin:1px;
+	margin-right:10px;
+	padding:3px;
 }
 
 .tf-med {

--- a/browserassets/html/pathoComp.html
+++ b/browserassets/html/pathoComp.html
@@ -206,6 +206,8 @@
 								<span class="label">Transient:</span>
 								<div class="annunciator a-green" id="annTransYes">YES</div>
 								<div class="annunciator a-red" id="annTransNo">NO</div>
+								<span class="label"></span>
+								<div class="text-field tf-med-long" id="analysisResult"></div>
 								<hr>
 								<span class="label">Error:</span>
 								<div class="annunciator a-red" id="annErrBuffer">BUFFER</div>

--- a/browserassets/html/pathoComp.html
+++ b/browserassets/html/pathoComp.html
@@ -203,11 +203,12 @@
 								<span class="label">Stable:</span>
 								<div class="annunciator a-green" id="annStableYes">YES</div>
 								<div class="annunciator a-red" id="annStableNo">NO</div>
+								<div class="text-field tf-med-long" id="stableType"></div>
 								<span class="label">Transient:</span>
 								<div class="annunciator a-green" id="annTransYes">YES</div>
 								<div class="annunciator a-red" id="annTransNo">NO</div>
-								<span class="label"></span>
-								<div class="text-field tf-med-long" id="analysisResult"></div>
+								<div class="text-field tf-med-narrow" id="transTypesGood"></div>
+								<div class="text-field tf-med-narrow" id="transTypesBad"></div>
 								<hr>
 								<span class="label">Error:</span>
 								<div class="annunciator a-red" id="annErrBuffer">BUFFER</div>

--- a/browserassets/js/pathology_display.js
+++ b/browserassets/js/pathology_display.js
@@ -83,6 +83,8 @@
 				var data = listing[k]
 				if (k != "seq")
 					data = prettifyYesNo(data);
+				else
+					data = insertSpaces(data);
 				html += "<td>" + data + "</td>";
 			}
 			html +="</tr>"
@@ -99,6 +101,17 @@
 			text = "<span style='font-weight:bold;color:#D00;'>" + text + "</span>";
 		}
 		return text
+	}
+	
+	// This inserts spaces between the individual segments of a sequence, so the list is less of an eyesore
+	function insertSpaces(text) {
+		var text2 = "";
+		for(i = 0; i < text.length; i++)
+		{
+			text2 += text.substring(i*3, (i+1)*3);
+			text2 += " ";
+		}
+		return text2;
 	}
 	
 	function getTableHeader() {

--- a/browserassets/js/pathoui-script.js
+++ b/browserassets/js/pathoui-script.js
@@ -501,7 +501,7 @@
 		{
 			$(id).removeClass("a-green-on");
 		}
-		else if($(id).hasClass("a-green-on"))
+		else if($(id).hasClass("a-red-on"))
 		{
 			$(id).removeClass("a-red-on");
 		}

--- a/browserassets/js/pathoui-script.js
+++ b/browserassets/js/pathoui-script.js
@@ -311,7 +311,7 @@
 
 	/* VARS */
 	var curSeq = [], prevSeq = [],
-	iStable = 0, iTrans = 0;
+	iStable = 0, iTrans = 0, iAnalysisResult = "";
 
 	/* WORKERS */
 	function seqEntry(seq, certainty) {
@@ -433,6 +433,7 @@
 			prevSeq = [];
 			iStable = data.stable;
 			iTrans = data.trans;
+			iAnalysisResult = data.analysisResult;
 			var s = data.seqs, c = data.conf;
 
 			if(s.length === c.length) {
@@ -491,12 +492,21 @@
 		}
 	}
 
+	function updateAnalysisResult(id, newResult) {
+		$(id + " .text-field").text("");
+		if(newResult) {
+				$(id).html("<span>" + newResult + "</span>");
+			}
+	}
+
 	function updateAnalysisControlElements() {
 		setAnnunciator("#annStableYes", iStable == 1);
 		setAnnunciator("#annStableNo", iStable == -1);
 
 		setAnnunciator("#annTransYes", iTrans == 1);
 		setAnnunciator("#annTransNo", iTrans == -1);
+		
+		updateAnalysisResult("#analysisResult", iAnalysisResult);
 
 
 		var invalid = !loadedDna || loadedDna.isSplicing;

--- a/browserassets/js/pathoui-script.js
+++ b/browserassets/js/pathoui-script.js
@@ -311,7 +311,7 @@
 
 	/* VARS */
 	var curSeq = [], prevSeq = [],
-	iStable = 0, iTrans = 0, iAnalysisResult = "";
+	iStable = 0, iTrans = 0, iStableType = "", iTransGood = "", iTransBad = "";
 
 	/* WORKERS */
 	function seqEntry(seq, certainty) {
@@ -433,7 +433,9 @@
 			prevSeq = [];
 			iStable = data.stable;
 			iTrans = data.trans;
-			iAnalysisResult = data.analysisResult;
+			iStableType = data.stableType;
+			iTransGood = data.transGood;
+			iTransBad = data.transBad;
 			var s = data.seqs, c = data.conf;
 
 			if(s.length === c.length) {
@@ -494,9 +496,22 @@
 
 	function updateAnalysisResult(id, newResult) {
 		$(id + " .text-field").text("");
-		if(newResult) {
-				$(id).html("<span>" + newResult + "</span>");
-			}
+		$(id).html("<span>" + newResult + "</span>");
+		if($(id).hasClass("a-green-on"))
+		{
+			$(id).removeClass("a-green-on");
+		}
+		else if($(id).hasClass("a-green-on"))
+		{
+			$(id).removeClass("a-red-on");
+		}
+		if(newResult == "Good") {
+			safeAddClass(id, "a-green-on");
+		} else if(newResult == "Bad")
+		{
+			safeAddClass(id, "a-red-on");
+		}
+		return 0;
 	}
 
 	function updateAnalysisControlElements() {
@@ -506,7 +521,9 @@
 		setAnnunciator("#annTransYes", iTrans == 1);
 		setAnnunciator("#annTransNo", iTrans == -1);
 		
-		updateAnalysisResult("#analysisResult", iAnalysisResult);
+		updateAnalysisResult("#stableType", iStableType);
+		updateAnalysisResult("#transTypesGood", iTransGood);
+		updateAnalysisResult("#transTypesBad", iTransBad);
 
 
 		var invalid = !loadedDna || loadedDna.isSplicing;

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -523,6 +523,9 @@
 
 	for (var/obj/item/implant/H in src.implant)
 		H.on_death()
+	for (var/uid in src.pathogens)
+		var/datum/pathogen/P = src.pathogens[uid]
+		P.ondeath()
 
 #ifdef DATALOGGER
 	game_stats.Increment("deaths")
@@ -636,7 +639,6 @@
 			remove_mindslave_status(src, "vthrall", "death")
 		else if (src.mind.master)
 			remove_mindslave_status(src, "otherslave", "death")
-
 	logTheThing("combat", src, null, "dies [log_health(src)] at [log_loc(src)].")
 	//src.icon_state = "dead"
 

--- a/code/mob/living/carbon/human/procs/Life.dm
+++ b/code/mob/living/carbon/human/procs/Life.dm
@@ -675,12 +675,14 @@
 		if (isdead(src))
 			if (src.pathogens.len)
 				for (var/uid in src.pathogens)
+					var/datum/pathogen/P = src.pathogens[uid]
+					P.disease_act_dead()
 					if (prob(5))
-						src.cured(src.pathogens[uid])
-			return
-		for (var/uid in src.pathogens)
-			var/datum/pathogen/P = src.pathogens[uid]
-			P.disease_act()
+						src.cured(P)
+		else
+			for (var/uid in src.pathogens)
+				var/datum/pathogen/P = src.pathogens[uid]
+				P.disease_act()
 
 	proc/handle_mutations_and_radiation()
 		if (bioHolder) bioHolder.OnLife()

--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -296,6 +296,7 @@
 	lockedTries = 6
 	stability_loss = 5
 	icon_state  = "haze"
+	isBad = 1
 
 /datum/bioEffect/dead_scan
 	name = "Pseudonecrosis"
@@ -305,6 +306,7 @@
 	probability = 99
 	stability_loss = 5
 	icon_state  = "dead"
+	isBad = 1
 
 ///////////////////
 // General buffs //

--- a/code/modules/medical/pathology/_pathogen_constants.dm
+++ b/code/modules/medical/pathology/_pathogen_constants.dm
@@ -1,0 +1,5 @@
+// Spread flags. Determines what slots are taken into account during a permeability scan.
+#define SPREAD_FACE 1
+#define SPREAD_BODY 2
+#define SPREAD_HANDS 4
+#define SPREAD_AIR 8

--- a/code/modules/medical/pathology/pathogen.dm
+++ b/code/modules/medical/pathology/pathogen.dm
@@ -1400,6 +1400,13 @@ datum/pathogen
 		for (var/effect in src.effects)
 			. *= effect:onemote(infected, act, src)
 
+	// Act when dying. Returns nothing.
+	proc/ondeath()
+		for (var/effect in src.effects)
+			effect:ondeath(infected, src)
+		suppressant.ondeath(src)
+		return
+
 	proc/add_new_symptom(var/list/allowed, var/allow_duplicates = 0)
 		for (var/i = 0, i < 10, i++)
 			var/T = pick(allowed)

--- a/code/modules/medical/pathology/pathogen.dm
+++ b/code/modules/medical/pathology/pathogen.dm
@@ -1339,6 +1339,38 @@ datum/pathogen
 	proc/remission()
 		in_remission = 1
 
+	// calculates the sum of the danger score of all symptoms, used for health scanner output
+	proc/danger_score()
+		var/score = 0
+		for (var/datum/pathogeneffects/effect in src.effects)
+			score += effect.danger_score
+		var/text = "[score], "
+		if(score > 40)
+			text += "incredibly deadly"
+		else if(score > 30)
+			text += "very deadly"
+		else if(score > 20)
+			text += "deadly"
+		else if(score > 15)
+			text += "potentially deadly"
+		else if(score > 10)
+			text += "dangerous"
+		else if(score > 5)
+			text += "potentially dangerous"
+		else if(score > 0)
+			text += "mostly harmless"
+		else if(score > -5)
+			text += "slightly beneficial"
+		else if(score > -10)
+			text += "potentially beneficial"
+		else if(score > -15)
+			text += "beneficial"
+		else if(score > -20)
+			text += "very beneficial"
+		else
+			text += "incredibly beneficial"
+		return text
+
 	//=============================================================================
 	//	Events
 	//=============================================================================

--- a/code/modules/medical/pathology/pathogen.dm
+++ b/code/modules/medical/pathology/pathogen.dm
@@ -119,6 +119,7 @@ datum/controller/pathogen
 			return
 		if (H in CDC.infections)
 			CDC.infections -= H
+		P.oncured()
 
 	proc/patient_zero(var/datum/pathogen_cdc/CDC, var/topic_holder)
 		if (CDC.patient_zero)
@@ -1431,6 +1432,13 @@ datum/pathogen
 		for (var/effect in src.effects)
 			effect:ondeath(infected, src)
 		suppressant.ondeath(src)
+		return
+
+	// Act when cured. Returns nothing.
+	proc/oncured()
+		for (var/effect in src.effects)
+			effect:oncured(infected, src)
+		suppressant.oncured(src)
 		return
 
 	proc/add_new_symptom(var/list/allowed, var/allow_duplicates = 0)

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -310,7 +310,7 @@ datum/pathogeneffects/benevolent/oxytocinproduction
 	permeability_score = 15
 	spread = SPREAD_BODY | SPREAD_HANDS
 	infection_coefficient = 1.5
-	infect_message = "<span style=\"color:pink\">You can't help but feel loved.</span>"
+	infect_message = "<span style=\"color:red\">You can't help but feel loved.</span>"
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -323,32 +323,3 @@ datum/pathogeneffects/benevolent/oxytocinproduction
 
 	may_react_to()
 		return "The pathogen's cells appear to be... hugging each other?"
-
-datum/pathogeneffects/benevolent/neuralreconstruction
-	name = "Neural Reconstruction"
-	desc = "Infection slowly repairs damage done to the brain."
-	rarity = RARITY_UNCOMMON
-	infect_type = INFECT_NONE
-	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
-		if (!origin.symptomatic)
-			return
-		switch (origin.stage)
-			if (2)
-				if (prob(5))
-					M.take_brain_damage(-1)
-			if (3)
-				if (prob(15))
-					M.take_brain_damage(-1)
-			if (4)
-				if (prob(25))
-					M.take_brain_damage(-2)
-			if (5)
-				if (prob(35))
-					M.take_brain_damage(-2)
-
-	react_to(var/R, var/zoom)
-		if (!(R == "neurotoxin"))
-			return "The pathogen seems to release a chemical in an attempt to counteract the effects of the neurotoxin."
-
-	may_react_to()
-		return "The pathogen appears to have a gland that may affect neural functions."

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -1,6 +1,7 @@
 datum/pathogeneffects/benevolent
 	name = "Benevolent"
 	rarity = RARITY_ABSTRACT
+	beneficial = 1
 
 datum/pathogeneffects/benevolent/mending
 	name = "Wound Mending"
@@ -247,6 +248,7 @@ datum/pathogeneffects/benevolent/brewery
 	name = "Auto-Brewery"
 	desc = "The pathogen aids the host body in metabolizing chemicals into ethanol."
 	rarity = RARITY_RARE
+	beneficial = 0 // fuck this liver disease isn't beneficial
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -297,7 +299,7 @@ datum/pathogeneffects/benevolent/bioluminescence
 				if("green")
 					return list(0, 255, 2505)
 				if("black") // fuck
-					return list(0, 0, 0)
+					return list(100, 100, 100)
 				if("cyan")
 					return list(0, 255, 255)
 				if("white")
@@ -311,7 +313,7 @@ datum/pathogeneffects/benevolent/bioluminescence
 				if("olive drab")
 					return list(107, 142, 35)
 				else
-					return list(255, 215, 0) // probably admin created, so let's make it gold!
+					return list(255, 215, 0) // probably admin created, so let's make it golden! Also, how is there even no yellow suppressant?
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -7,6 +7,7 @@ datum/pathogeneffects/benevolent/mending
 	name = "Wound Mending"
 	desc = "Slow paced brute damage healing."
 	rarity = RARITY_UNCOMMON
+	danger_score = -6
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -27,6 +28,7 @@ datum/pathogeneffects/benevolent/healing
 	name = "Burn Healing"
 	desc = "Slow paced burn damage healing."
 	rarity = RARITY_UNCOMMON
+	danger_score = -6
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -50,6 +52,7 @@ datum/pathogeneffects/benevolent/detoxication
 	name = "Detoxication"
 	desc = "The pathogen aids the host body in metabolizing ethanol."
 	rarity = RARITY_COMMON
+	danger_score = -2
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -85,6 +88,7 @@ datum/pathogeneffects/benevolent/metabolisis
 	name = "Accelerated Metabolisis"
 	desc = "The pathogen accelerates the metabolisis of all chemicals present in the host body."
 	rarity = RARITY_RARE
+	danger_score = 0
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -119,6 +123,7 @@ datum/pathogeneffects/benevolent/cleansing
 	name = "Cleansing"
 	desc = "The pathogen cleans the body of damage caused by toxins."
 	rarity = RARITY_RARE
+	danger_score = -6
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -143,6 +148,7 @@ datum/pathogeneffects/benevolent/oxygenconversion
 	name = "Oxygen Conversion"
 	desc = "The pathogen converts organic tissue into oxygen."
 	rarity = RARITY_VERY_RARE
+	danger_score = 0
 
 	may_react_to()
 		return "The pathogen appears to radiate a bubble of oxygen."
@@ -168,6 +174,7 @@ datum/pathogeneffects/benevolent/oxygenproduction
 	name = "Oxygen Production"
 	desc = "The pathogen produces oxygen."
 	rarity = RARITY_VERY_RARE
+	danger_score = -6
 
 	may_react_to()
 		return "The pathogen appears to radiate a bubble of oxygen."
@@ -185,6 +192,7 @@ datum/pathogeneffects/benevolent/resurrection
 	name = "Necrotic Resurrection"
 	desc = "The pathogen will resurrect you if it procs while you are dead."
 	rarity = RARITY_VERY_RARE
+	danger_score = -15
 
 	may_react_to()
 		return "Some of the pathogen's dead cells seem to remain active."
@@ -249,6 +257,7 @@ datum/pathogeneffects/benevolent/brewery
 	desc = "The pathogen aids the host body in metabolizing chemicals into ethanol."
 	rarity = RARITY_RARE
 	beneficial = 0 // fuck this liver disease isn't beneficial
+	danger_score = 6
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -287,6 +296,8 @@ datum/pathogeneffects/benevolent/bioluminescence
 	name = "Bioluminescence"
 	desc = "The pathogen makes the afflicted emit light and sometimes flash the area when attacked."
 	rarity = RARITY_RARE
+	danger_score = -8
+
 	var/rgb = null
 	
 	proc/getColor(var/datum/pathogen/origin)

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -270,3 +270,32 @@ datum/pathogeneffects/benevolent/oxytocinproduction
 
 	may_react_to()
 		return "The pathogen's cells appear to be... hugging each other?"
+
+datum/pathogeneffects/benevolent/neuralreconstruction
+	name = "Neural Reconstruction"
+	desc = "Infection slowly repairs damage done to the brain."
+	rarity = RARITY_UNCOMMON
+	infect_type = INFECT_NONE
+	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
+		if (!origin.symptomatic)
+			return
+		switch (origin.stage)
+			if (2)
+				if (prob(5))
+					M.take_brain_damage(-1)
+			if (3)
+				if (prob(15))
+					M.take_brain_damage(-1)
+			if (4)
+				if (prob(25))
+					M.take_brain_damage(-2)
+			if (5)
+				if (prob(35))
+					M.take_brain_damage(-2)
+
+	react_to(var/R, var/zoom)
+		if (!(R == "neurotoxin"))
+			return "The pathogen seems to release a chemical in an attempt to counteract the effects of the neurotoxin."
+
+	may_react_to()
+		return "The pathogen appears to have a gland that may affect neural functions."

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -191,20 +191,23 @@ datum/pathogeneffects/benevolent/resurrection
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
-		if (origin.stage < 5)
+		if (origin.stage < 3)
 			return
-		if(prob(5))
+		if(prob(10 + origin.stage))
+			M.emote("moan")
+		if(prob(2 + origin.stage))
 			M.show_message("<span style=\"color:red\">You feel a sudden craving for ... brains??</span>")
 
 	disease_act_dead(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
-		if (origin.stage < 5)
+		if (origin.stage < 3)
 			return
 		// Shamelessly stolen from Strange Reagent
 		if (isdead(M) || istype(get_area(M),/area/afterlife/bar))
-			var/brute = M.get_brute_damage()>45?45:M.get_brute_damage()
-			var/burn = M.get_burn_damage()>45?45:M.get_burn_damage()
+			var/cap = 75 - origin.stage*6
+			var/brute = (M.get_brute_damage()>cap)?(cap):M.get_brute_damage()
+			var/burn = (M.get_burn_damage()>cap)?(cap):M.get_burn_damage()
 
 			// let's heal them before we put some of the damage back
 			// but they don't get back organs/limbs/whatever, so I don't use full_heal
@@ -216,7 +219,7 @@ datum/pathogeneffects/benevolent/resurrection
 				H.take_oxygen_deprivation(-INFINITY)
 
 			M.TakeDamage("chest", brute, burn)			// this makes it so our burn and brute are between 0-45, so at worst we will have 10% hp
-			M.take_brain_damage(70)						// and a lot of brain damage
+			M.take_brain_damage(cap)				// and a lot of brain damage
 			setalive(M)
 			M.changeStatus("paralysis", 150) 			// paralyze the person for a while, because coming back to life is hard work
 			M.change_misstep_chance(40)					// even after getting up they still have some grogginess for a while
@@ -234,8 +237,10 @@ datum/pathogeneffects/benevolent/resurrection
 				H.visible_message("<span style=\"color:red\">[H] suddenly starts moving again!</span>","<span style=\"color:red\">You feel the pathogen weakening as you rise from the dead.</span>")
 
 	react_to(var/R, var/zoom)
-		if (R == "Synthflesh")
+		if (R == "synthflesh")
+			if (zoom)
 			return "Dead parts of the synthflesh seem to still be transferring blood."
+		else return null
 
 
 datum/pathogeneffects/benevolent/brewery

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -213,7 +213,7 @@ datum/pathogeneffects/benevolent/resurrection
 	rarity = RARITY_VERY_RARE
 
 	may_react_to()
-		return "Some of the dead pathogen cells seem to remain active."
+		return "Some of the pathogen's dead cells seem to remain active."
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -1,3 +1,8 @@
+#define SPREAD_FACE 1
+#define SPREAD_BODY 2
+#define SPREAD_HANDS 4
+#define SPREAD_AIR 8
+
 datum/pathogeneffects/benevolent
 	name = "Benevolent"
 	rarity = RARITY_ABSTRACT
@@ -5,13 +10,13 @@ datum/pathogeneffects/benevolent
 datum/pathogeneffects/benevolent/mending
 	name = "Wound Mending"
 	desc = "Slow paced brute damage healing."
-	rarity = RARITY_UNCOMMON
+	rarity = RARITY_COMMON
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
-		if (prob(origin.stage * 5))
-			M.HealDamage("chest", origin.stage < 3 ? 1 : 2, 0)
+		//if (prob(origin.stage * 5))
+		M.HealDamage("All", origin.stage / 2, 0)
 		M.updatehealth()
 
 	react_to(var/R, var/zoom)
@@ -25,13 +30,13 @@ datum/pathogeneffects/benevolent/mending
 datum/pathogeneffects/benevolent/healing
 	name = "Burn Healing"
 	desc = "Slow paced burn damage healing."
-	rarity = RARITY_UNCOMMON
+	rarity = RARITY_COMMON
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
-		if (prob(origin.stage * 5))
-			M.HealDamage("chest", 0, origin.stage < 3 ? 1 : 2)
+		//if (prob(origin.stage * 5))
+		M.HealDamage("All", 0, origin.stage / 2)
 		M.updatehealth()
 
 	react_to(var/R, var/zoom)
@@ -44,6 +49,36 @@ datum/pathogeneffects/benevolent/healing
 
 	may_react_to()
 		return "The pathogen appears to have the ability to bond with organic tissue."
+
+datum/pathogeneffects/benevolent/fleshrestructuring
+	name = "Flesh Restructuring"
+	desc = "Fast paced general healing."
+	rarity = RARITY_RARE
+
+	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
+		if (!origin.symptomatic)
+			return
+		if (prob(origin.stage * 5))
+			M.HealDamage("All", origin.stage, origin.stage)
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				if(H.bleeding)
+					repair_bleeding_damage(M, 80, 2)
+			if (prob(50))
+				M.show_message("<span style=\"color:blue\">You feel your wounds closing by themselves.</span>")
+		M.updatehealth()
+
+	react_to(var/R, var/zoom)
+		if (R == "synthflesh")
+			if (zoom)
+				return "The pathogen appears to mimic the behavior of the synthetic flesh."
+		if (R == "acid")
+			if (zoom)
+				return "The pathogen becomes agitated and works to repair the damage caused by the sulfuric acid."
+
+	may_react_to()
+		return "The pathogen appears to have the ability to bond with organic tissue to an unprecedented degree."
+	//podrickequus's first code, yay
 
 datum/pathogeneffects/benevolent/detoxication
 	name = "Detoxication"
@@ -112,31 +147,28 @@ datum/pathogeneffects/benevolent/metabolisis
 		return "The pathogen appears to have entirely metabolized... all chemical agents in the dish."
 
 	may_react_to()
-		return null
+		return "The pathogen appears to be rapidly breaking down certain materials around it."
 
 datum/pathogeneffects/benevolent/cleansing
 	name = "Cleansing"
 	desc = "The pathogen cleans the body of damage caused by toxins."
-	rarity = RARITY_RARE
+	rarity = RARITY_UNCOMMON
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
-		if (prob(origin.stage * 5) && M.get_toxin_damage())
-			M.take_toxin_damage(-1)
-			if (origin.stage > 3)
-				M.take_toxin_damage(-1)
-				if (origin.stage > 4)
-					M.take_toxin_damage(-1)
+		//if (prob(origin.stage * 5) && M.get_toxin_damage())
+		if (M.get_toxin_damage())
+			M.take_toxin_damage(-origin.stage / 2)
 			M.updatehealth()
-			if (prob(10))
+			if (prob(12))
 				M.show_message("<span style=\"color:blue\">You feel cleansed.</span>")
 
 	react_to(var/R, var/zoom)
 		return "The pathogen appears to have entirely metabolized... all chemical agents in the dish."
 
 	may_react_to()
-		return null
+		return "The pathogen seems to be much cleaner than normal."
 
 datum/pathogeneffects/benevolent/oxygenconversion
 	name = "Oxygen Conversion"
@@ -216,3 +248,25 @@ datum/pathogeneffects/benevolent/brewery
 
 	may_react_to()
 		return "The pathogen appears to react with anything but a pure intoxicant."
+
+datum/pathogeneffects/benevolent/oxytocinproduction
+	name = "Oxytocin Production"
+	desc = "The pathogen produces Pure Love within the infected."
+	infect_type = INFECT_TOUCH
+	rarity = RARITY_COMMON
+	permeability_score = 15
+	spread = SPREAD_BODY | SPREAD_HANDS
+	infection_coefficient = 1.5
+	infect_message = "<span style=\"color:red\">You can't help but feel loved.</span>"
+
+	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
+		if (!origin.symptomatic)
+			return
+		var/check_amount = M.reagents.get_reagent_amount("love")
+		if (!check_amount || check_amount < 5)
+			M.reagents.add_reagent("love", origin.stage / 2)
+		if (prob(origin.stage * 2.5))
+			infect(M, origin)
+
+	may_react_to()
+		return "The pathogen's cells appear to be... hugging each other?"

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -214,7 +214,7 @@ datum/pathogeneffects/benevolent/oxygenproduction
 
 datum/pathogeneffects/benevolent/resurrection
 	name = "Resurrection"
-	desc = "The pathogen resurrects you. Fuck you I don't get paid to write descriptions! Sorry for swearing, It's late. I hope we can remain friends...."
+	desc = "The pathogen will resurrect you if it procs while you are dead."
 	rarity = RARITY_VERY_RARE
 
 	may_react_to()
@@ -225,9 +225,10 @@ datum/pathogeneffects/benevolent/resurrection
 			return
 		if (origin.stage < 5)
 			return
-		M.show_message("<span style=\"color:red\">Read to die!</span>")
+		if(prob(5))
+			M.show_message("<span style=\"color:red\">You feel a sudden craving for ... brains??</span>")
 
-	ondeath(var/mob/M as mob, var/datum/pathogen/origin)
+	disease_act_dead(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
 		if (origin.stage < 5)
@@ -251,9 +252,9 @@ datum/pathogeneffects/benevolent/resurrection
 			if (ishuman(M))
 				var/mob/living/carbon/human/H = M
 				H.contract_disease(/datum/ailment/disease/tissue_necrosis, null, null, 1) // this disease will make the person more and more rotten even while alive
-				H.cured(origin)			// cure the pathogen and immunize us against it, so we can't use it twice!
+				H.remission(origin)			// set the pathogen into remission, so it will be gone soon. Unlikely for a person to revive twice like this!
 				H.immunity(origin)
-				H.visible_message("<span style=\"color:red\">[H] seems to rise from the dead!</span>","<span style=\"color:red\">You feel the pathogen leaving your body as you rise from the dead.</span>")
+				H.visible_message("<span style=\"color:red\">[H] suddenly starts moving again!</span>","<span style=\"color:red\">You feel the pathogen weakening as you rise from the dead.</span>")
 
 
 datum/pathogeneffects/benevolent/brewery

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -257,7 +257,7 @@ datum/pathogeneffects/benevolent/oxytocinproduction
 	permeability_score = 15
 	spread = SPREAD_BODY | SPREAD_HANDS
 	infection_coefficient = 1.5
-	infect_message = "<span style=\"color:red\">You can't help but feel loved.</span>"
+	infect_message = "<span style=\"color:pink\">You can't help but feel loved.</span>"
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -209,7 +209,7 @@ datum/pathogeneffects/benevolent/resurrection
 			M.take_brain_damage(70)				// and a lot of brain damage
 			setalive(M)
 			M.changeStatus("paralysis", 150) 	// paralyze the person for a while, because coming back to life is hard work
-			M.change_misstep_chance(30)			// even after getting up they still have some grogginess for a while
+			M.change_misstep_chance(40)			// even after getting up they still have some grogginess for a while
 			M.stuttering = 15
 			M.updatehealth()
 			if (M.ghost && M.ghost.mind && !(M.mind && M.mind.dnr)) // if they have dnr set don't bother shoving them back in their body

--- a/code/modules/medical/pathology/pathogen_benevolent.dm
+++ b/code/modules/medical/pathology/pathogen_benevolent.dm
@@ -5,13 +5,13 @@ datum/pathogeneffects/benevolent
 datum/pathogeneffects/benevolent/mending
 	name = "Wound Mending"
 	desc = "Slow paced brute damage healing."
-	rarity = RARITY_COMMON
+	rarity = RARITY_UNCOMMON
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
-		//if (prob(origin.stage * 5))
-		M.HealDamage("All", origin.stage / 2, 0)
+		if (prob(origin.stage * 5))
+			M.HealDamage("chest", origin.stage < 3 ? 1 : 2, 0)
 		M.updatehealth()
 
 	react_to(var/R, var/zoom)
@@ -25,13 +25,13 @@ datum/pathogeneffects/benevolent/mending
 datum/pathogeneffects/benevolent/healing
 	name = "Burn Healing"
 	desc = "Slow paced burn damage healing."
-	rarity = RARITY_COMMON
+	rarity = RARITY_UNCOMMON
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
-		//if (prob(origin.stage * 5))
-		M.HealDamage("All", 0, origin.stage / 2)
+		if (prob(origin.stage * 5))
+			M.HealDamage("chest", 0, origin.stage < 3 ? 1 : 2)
 		M.updatehealth()
 
 	react_to(var/R, var/zoom)
@@ -44,36 +44,6 @@ datum/pathogeneffects/benevolent/healing
 
 	may_react_to()
 		return "The pathogen appears to have the ability to bond with organic tissue."
-
-datum/pathogeneffects/benevolent/fleshrestructuring
-	name = "Flesh Restructuring"
-	desc = "Fast paced general healing."
-	rarity = RARITY_RARE
-
-	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
-		if (!origin.symptomatic)
-			return
-		if (prob(origin.stage * 5))
-			M.HealDamage("All", origin.stage, origin.stage)
-			if(ishuman(M))
-				var/mob/living/carbon/human/H = M
-				if(H.bleeding)
-					repair_bleeding_damage(M, 80, 2)
-			if (prob(50))
-				M.show_message("<span style=\"color:blue\">You feel your wounds closing by themselves.</span>")
-		M.updatehealth()
-
-	react_to(var/R, var/zoom)
-		if (R == "synthflesh")
-			if (zoom)
-				return "The pathogen appears to mimic the behavior of the synthetic flesh."
-		if (R == "acid")
-			if (zoom)
-				return "The pathogen becomes agitated and works to repair the damage caused by the sulfuric acid."
-
-	may_react_to()
-		return "The pathogen appears to have the ability to bond with organic tissue to an unprecedented degree."
-	//podrickequus's first code, yay
 
 datum/pathogeneffects/benevolent/detoxication
 	name = "Detoxication"
@@ -142,28 +112,31 @@ datum/pathogeneffects/benevolent/metabolisis
 		return "The pathogen appears to have entirely metabolized... all chemical agents in the dish."
 
 	may_react_to()
-		return "The pathogen appears to be rapidly breaking down certain materials around it."
+		return null
 
 datum/pathogeneffects/benevolent/cleansing
 	name = "Cleansing"
 	desc = "The pathogen cleans the body of damage caused by toxins."
-	rarity = RARITY_UNCOMMON
+	rarity = RARITY_RARE
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
-		//if (prob(origin.stage * 5) && M.get_toxin_damage())
-		if (M.get_toxin_damage())
-			M.take_toxin_damage(-origin.stage / 2)
+		if (prob(origin.stage * 5) && M.get_toxin_damage())
+			M.take_toxin_damage(-1)
+			if (origin.stage > 3)
+				M.take_toxin_damage(-1)
+				if (origin.stage > 4)
+					M.take_toxin_damage(-1)
 			M.updatehealth()
-			if (prob(12))
+			if (prob(10))
 				M.show_message("<span style=\"color:blue\">You feel cleansed.</span>")
 
 	react_to(var/R, var/zoom)
 		return "The pathogen appears to have entirely metabolized... all chemical agents in the dish."
 
 	may_react_to()
-		return "The pathogen seems to be much cleaner than normal."
+		return null
 
 datum/pathogeneffects/benevolent/oxygenconversion
 	name = "Oxygen Conversion"
@@ -301,25 +274,3 @@ datum/pathogeneffects/benevolent/brewery
 
 	may_react_to()
 		return "The pathogen appears to react with anything but a pure intoxicant."
-
-datum/pathogeneffects/benevolent/oxytocinproduction
-	name = "Oxytocin Production"
-	desc = "The pathogen produces Pure Love within the infected."
-	infect_type = INFECT_TOUCH
-	rarity = RARITY_COMMON
-	permeability_score = 15
-	spread = SPREAD_BODY | SPREAD_HANDS
-	infection_coefficient = 1.5
-	infect_message = "<span style=\"color:red\">You can't help but feel loved.</span>"
-
-	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
-		if (!origin.symptomatic)
-			return
-		var/check_amount = M.reagents.get_reagent_amount("love")
-		if (!check_amount || check_amount < 5)
-			M.reagents.add_reagent("love", origin.stage / 2)
-		if (prob(origin.stage * 2.5))
-			infect(M, origin)
-
-	may_react_to()
-		return "The pathogen's cells appear to be... hugging each other?"

--- a/code/modules/medical/pathology/pathogen_machines.dm
+++ b/code/modules/medical/pathology/pathogen_machines.dm
@@ -627,7 +627,7 @@
 								if (i == bits)
 									// get symptom from dna, so we can check if it is good or bad
 									var/sym = pathogen_controller.path_to_symptom[pathogen_controller.UID_to_symptom[dna]]
-									if(istype(sym, /datum/pathogeneffects/benevolent))
+									if (sym:beneficial)
 										stableType = "Good"
 									else
 										stableType = "Bad"
@@ -639,7 +639,7 @@
 								if (i == bits)
 									// get symptom from dna, so we can check if it is good or bad
 									var/sym = pathogen_controller.path_to_symptom[pathogen_controller.UID_to_symptom[dna]]
-									if(istype(sym, /datum/pathogeneffects/benevolent))
+									if(sym:beneficial)
 										transGood++
 									else
 										transBad++

--- a/code/modules/medical/pathology/pathogen_machines.dm
+++ b/code/modules/medical/pathology/pathogen_machines.dm
@@ -1535,7 +1535,7 @@
 					if (found)
 						is_cure = 1
 				else
-					found = 1
+					is_cure = 1
 		if (use_antiagent && src.antiagent)
 			src.antiagent.reagents.clear_reagents()
 		if (use_suppressant && src.suppressant)

--- a/code/modules/medical/pathology/pathogen_machines.dm
+++ b/code/modules/medical/pathology/pathogen_machines.dm
@@ -598,6 +598,7 @@
 			//Result variables
 			var/stable = 0
 			var/transient = 0
+			var/analysisResult = ""
 			var/seqs = "\["
 			var/conf = "\["
 			var/delim = ""
@@ -614,6 +615,8 @@
 				var/acc_len = lentext(acc)
 				var/total = 0
 				var/match = 0
+				var/good = 0
+				var/bad = 0
 				for (var/dna in pathogen_controller.UID_to_symptom)
 					var/dnalen = lentext(dna)
 					if (dnalen >= acc_len)
@@ -626,6 +629,13 @@
 						else
 							if (copytext(dna, 1, acc_len + 1) == acc)
 								match++
+								// get symptom from dna, so we can check if it is good or bad
+								var/sym = pathogen_controller.path_to_symptom[pathogen_controller.UID_to_symptom[dna]]
+								message_admins("[sym]")
+								if(istype(sym, /datum/pathogeneffects/benevolent))
+									good++
+								else
+									bad++
 				var/ratio = 0
 				if (total)
 					ratio = match / total
@@ -640,17 +650,19 @@
 					//output += "Transient: <font color='#00ff00'>Yes</font><BR>"
 					transient = 1
 					db.transient_sequences[analyzed] = "Yes"
+					analysisResult = num2text(good) + " good " + "/" + num2text(bad) + " bad"
 				else if (i == bits)
 					//output += "Transient: <font color='#ff0000'>No</font><BR>"
 					transient = -1
 					db.transient_sequences[analyzed] = "No"
+					analysisResult = "-"
 			seqs += "]"
 			conf += "]"
 
 			if (!stable)
 				src.manip.analysis = null
 				stable = -1
-			var/output = {"{"valid":1,"stable":[stable],"trans":[transient],"seqs":[seqs],"conf":[conf]}"}
+			var/output = {"{"valid":1,"stable":[stable],"trans":[transient],"seqs":[seqs],"conf":[conf],"analysisResult":\"[analysisResult]\"}"}
 			src.manip.last_analysis = output
 			//gui.sendToSubscribers(output, "handleAnalysisTestCallback")
 			sendAnalysisData()

--- a/code/modules/medical/pathology/pathogen_machines.dm
+++ b/code/modules/medical/pathology/pathogen_machines.dm
@@ -631,7 +631,6 @@
 								match++
 								// get symptom from dna, so we can check if it is good or bad
 								var/sym = pathogen_controller.path_to_symptom[pathogen_controller.UID_to_symptom[dna]]
-								message_admins("[sym]")
 								if(istype(sym, /datum/pathogeneffects/benevolent))
 									good++
 								else

--- a/code/modules/medical/pathology/pathogen_machines.dm
+++ b/code/modules/medical/pathology/pathogen_machines.dm
@@ -649,7 +649,7 @@
 					//output += "Transient: <font color='#00ff00'>Yes</font><BR>"
 					transient = 1
 					db.transient_sequences[analyzed] = "Yes"
-					analysisResult = num2text(good) + " good " + "/" + num2text(bad) + " bad"
+					analysisResult = num2text(good) + " good " + "   " + num2text(bad) + " bad"
 				else if (i == bits)
 					//output += "Transient: <font color='#ff0000'>No</font><BR>"
 					transient = -1

--- a/code/modules/medical/pathology/pathogen_suppressants.dm
+++ b/code/modules/medical/pathology/pathogen_suppressants.dm
@@ -36,6 +36,7 @@
 	proc/onadd(var/datum/pathogen/P)
 	proc/onemote(var/mob/target, message, var/datum/pathogen/P)
 	proc/ondeath(var/datum/pathogen/P)
+	proc/oncured(var/datum/pathogen/P)
 
 	// While doing pathogen research, the suppression method may define how the pathogen reacts to certain reagents.
 	// Returns null if the pathogen does not react to the reagent.

--- a/code/modules/medical/pathology/pathogen_suppressants.dm
+++ b/code/modules/medical/pathology/pathogen_suppressants.dm
@@ -35,6 +35,7 @@
 	proc/onsay(message, var/datum/pathogen/P)
 	proc/onadd(var/datum/pathogen/P)
 	proc/onemote(var/mob/target, message, var/datum/pathogen/P)
+	proc/ondeath(var/datum/pathogen/P)
 
 	// While doing pathogen research, the suppression method may define how the pathogen reacts to certain reagents.
 	// Returns null if the pathogen does not react to the reagent.

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -1598,7 +1598,7 @@ datum/pathogeneffects/malevolent/ultimatefever
 						var/IC = M.loc
 						M.set_loc(get_turf(M))
 						qdel(IC)
-				if (prob(2) && !M.bioHolder.HasEffect("fire_resist") &&  !M.bioHolder.HasEffect("thermal_resist") )
+				if (prob(2) && !M.bioHolder.HasOneOfTheseEffects("fire_resist","thermal_resist"))
 					M.show_message("<span style=\"color:red\">You completely burn up!</span>")
 					logTheThing("pathology", M, null, " is firegibbed due to symptom [src].")
 					M.firegib()
@@ -1771,7 +1771,7 @@ datum/pathogeneffects/malevolent/seriouschills/ultimate
 						M.show_message("<span style=\"color:red\">[pick("You're freezing!", "You're getting cold...", "So very cold...", "You feel your skin turning into ice...")]</span>")
 						M.changeStatus("stunned", 3 SECONDS)
 						M.emote("shiver")
-				if (prob(1) && !M.bioHolder.HasEffect("cold_resist") &&  !M.bioHolder.HasEffect("thermal_resist"))
+				if (prob(1) && !M.bioHolder.HasOneOfTheseEffects("cold_resist","thermal_resist"))
 					M.show_message("<span style=\"color:red\">You freeze completely!</span>")
 					logTheThing("pathology", usr, null, "was ice statuified by symptom [src].")
 					M:become_ice_statue()

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -116,6 +116,11 @@ datum/pathogeneffects
 	proc/onemote(var/mob/target, act, var/datum/pathogen/P)
 		return 1
 
+	// ondeath(mob, datum/pathogen) : void
+	// OVERRIDE: Overriding this is situational.
+	proc/ondeath(var/mob/M as mob, var/datum/pathogen/origin)
+		return
+
 	// End of events: please do not add any event definitions outside this block.
 	// ====
 

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -1596,7 +1596,7 @@ datum/pathogeneffects/malevolent/ultimatefever
 						var/IC = M.loc
 						M.set_loc(get_turf(M))
 						qdel(IC)
-				if (prob(2))
+				if (prob(2) && !M.bioHolder.HasEffect("fire_resist") &&  !M.bioHolder.HasEffect("thermal_resist") )
 					M.show_message("<span style=\"color:red\">You completely burn up!</span>")
 					logTheThing("pathology", M, null, " is firegibbed due to symptom [src].")
 					M.firegib()
@@ -1769,7 +1769,7 @@ datum/pathogeneffects/malevolent/seriouschills/ultimate
 						M.show_message("<span style=\"color:red\">[pick("You're freezing!", "You're getting cold...", "So very cold...", "You feel your skin turning into ice...")]</span>")
 						M.changeStatus("stunned", 3 SECONDS)
 						M.emote("shiver")
-				if (prob(1))
+				if (prob(1) && !M.bioHolder.HasEffect("cold_resist") &&  !M.bioHolder.HasEffect("thermal_resist"))
 					M.show_message("<span style=\"color:red\">You freeze completely!</span>")
 					logTheThing("pathology", usr, null, "was ice statuified by symptom [src].")
 					M:become_ice_statue()

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -2268,3 +2268,22 @@ datum/pathogeneffects/malevolent/snaps/wild
 				return "The individual microbodies appear to be playing some form of freeform jazz. They are clearly off-key."
 			else
 				return "The pathogen appears to be using the powder granules to make microscopic... saxophones???"
+
+
+datum/pathogeneffects/malevolent/detonation
+	name = "Necrotic Detonation"
+	desc = "The pathogen will cause you to violently explode upon death."
+	rarity = RARITY_VERY_RARE
+
+	may_react_to()
+		return "Some of the pathogen's dead cells seem to remain active."
+
+	ondeath(mob/M as mob, var/datum/pathogen/origin)
+		if (!origin.symptomatic)
+			return
+		explosion_new(M, get_turf(M), origin.stage*5, origin.stage/2.5)
+
+	react_to(var/R, var/zoom)
+		if (R == "Synthflesh")
+			return "There are stray synthflesh pieces all over the dish."
+

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -385,7 +385,7 @@ datum/pathogeneffects/malevolent/gasping
 	may_react_to()
 		return "The pathogen appears to create bubbles of vacuum around its affected area."
 
-datum/pathogeneffects/malevolent/moaning
+/*datum/pathogeneffects/malevolent/moaning
 	name = "Moaning"
 	desc = "This is literally pointless."
 	infect_type = INFECT_NONE
@@ -447,7 +447,7 @@ datum/pathogeneffects/malevolent/hiccups
 					M:emote("hiccup")
 
 	may_react_to()
-		return "The pathogen appears to be violently... hiccuping?"
+		return "The pathogen appears to be violently... hiccuping?"*/
 
 datum/pathogeneffects/malevolent/shivering
 	name = "Shivering"

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -33,6 +33,11 @@ datum/pathogeneffects
 	// OVERRIDE: A subclass (direct or otherwise) is expected to override this.
 	proc/disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 
+	// disease_act_dead(mob, datum/pathogen) : void
+	// This functions identically to disease_act, except it is only called when the mob is dead. (disease_act is not called if that is the case.)
+	// OVERRIDE: Only override this if if it needed for the symptom.
+	proc/disease_act_dead(var/mob/M as mob, var/datum/pathogen/origin)
+
 	// infect(mob, datum/pathogen) : void
 	// This is the proc that will handle infection. Infection does not occur on every single tick, as previously. Instead symptoms will independently decide when it would be appropriate to
 	// infect mobs nearby. For example, a coughing symptom shouldn't infect everyone everywhere, but as soon as the affected person coughs they should infect everyone nearby.

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -1893,6 +1893,8 @@ datum/pathogeneffects/malevolent/leprosy
 							SPAWN_DBG(rand(150, 200))
 								if (limb.remove_stage == 2)
 									limb.remove(0)
+	may_react_to()
+		return "The pathogen appears to be rapidly breaking down certain materials around it."
 
 datum/pathogeneffects/malevolent/senility
 	name = "Senility"
@@ -1929,6 +1931,8 @@ datum/pathogeneffects/malevolent/senility
 					M.show_message("<span style=\"color:red\">You completely forget what you were doing.</span>")
 					M.drop_item()
 					M.take_brain_damage(4)
+	may_react_to()
+		return "The pathogen appears to have a gland that may affect neural functions."
 
 datum/pathogeneffects/malevolent/beesneeze
 	name = "Projectile Bee Egg Sneezing"

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -2284,7 +2284,10 @@ datum/pathogeneffects/malevolent/detonation
 			return
 		explosion_new(M, get_turf(M), origin.stage*5, origin.stage/2.5)
 
+
 	react_to(var/R, var/zoom)
-		if (R == "Synthflesh")
+		if (R == "synthflesh")
+			if (zoom)
 			return "There are stray synthflesh pieces all over the dish."
+		else return null
 

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -8,6 +8,7 @@ datum/pathogeneffects
 	var/name
 	var/desc
 	var/infect_type = 0
+	var/danger_score = 0      // used for health scanner rating, positive is bad symptom, negative is good symptom
 
 	// A symptom with a lower permeability score needs more protective gear to evade.
 	var/permeability_score = 20
@@ -236,7 +237,9 @@ datum/pathogeneffects/malevolent/coughing
 	infect_type = INFECT_AREA
 	rarity = RARITY_COMMON
 	permeability_score = 15
+	danger_score = 1
 	spread = SPREAD_FACE | SPREAD_HANDS | SPREAD_AIR
+
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
@@ -273,6 +276,7 @@ datum/pathogeneffects/malevolent/indigestion
 	name = "Indigestion"
 	desc = "A bad case of indigestion which occasionally cramps the infected."
 	rarity = RARITY_VERY_COMMON
+	danger_score = 1
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -301,6 +305,7 @@ datum/pathogeneffects/malevolent/muscleache
 	name = "Muscle Ache"
 	desc = "The infected feels a slight, constant aching of muscles."
 	rarity = RARITY_COMMON
+	danger_score = 1
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -331,6 +336,7 @@ datum/pathogeneffects/malevolent/sneezing
 	infect_type = INFECT_AREA_LARGE
 	rarity = RARITY_COMMON
 	permeability_score = 25
+	danger_score = 0
 	spread = SPREAD_FACE | SPREAD_HANDS | SPREAD_AIR | SPREAD_BODY
 	infection_coefficient = 2
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
@@ -372,6 +378,7 @@ datum/pathogeneffects/malevolent/gasping
 	desc = "The infected has trouble breathing.."
 	infect_type = INFECT_NONE
 	rarity = RARITY_VERY_COMMON
+	danger_score = 1
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
@@ -407,6 +414,7 @@ datum/pathogeneffects/malevolent/moaning
 	desc = "This is literally pointless."
 	infect_type = INFECT_NONE
 	rarity = RARITY_VERY_COMMON
+	danger_score = 0
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
@@ -439,6 +447,7 @@ datum/pathogeneffects/malevolent/hiccups
 	desc = "This is literally pointless."
 	infect_type = INFECT_NONE
 	rarity = RARITY_VERY_COMMON
+	danger_score = 0
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
@@ -471,6 +480,7 @@ datum/pathogeneffects/malevolent/shivering
 	desc = "This is literally pointless."
 	infect_type = INFECT_NONE
 	rarity = RARITY_VERY_COMMON
+	danger_score = 0
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
@@ -503,6 +513,7 @@ datum/pathogeneffects/malevolent/deathgasping
 	desc = "This is literally pointless."
 	infect_type = INFECT_NONE
 	rarity = RARITY_UNCOMMON
+	danger_score = 0
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
@@ -538,6 +549,7 @@ datum/pathogeneffects/malevolent/sweating
 	permeability_score = 25
 	spread = SPREAD_HANDS | SPREAD_BODY
 	infection_coefficient = 1.5
+	danger_score = 0
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		switch (origin.stage)
 			if (1)
@@ -582,6 +594,7 @@ datum/pathogeneffects/malevolent/disorientation
 	desc = "The infected occasionally gets disoriented."
 	infect_type = INFECT_NONE
 	rarity = RARITY_UNCOMMON
+	danger_score = 10
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
@@ -646,6 +659,7 @@ datum/pathogeneffects/malevolent/serious_paranoia
 	desc = "The infected is seriously suspicious of others, to the point where they might see others do traitorous things."
 	infect_type = INFECT_NONE
 	rarity = RARITY_RARE
+	danger_score = 4
 	var/static/list/hallucinated_images = list(/obj/item/sword, /obj/item/card/emag, /obj/item/cloaking_device)
 	var/static/list/traitor_items = list("cyalume saber", "Electromagnetic Card", "pen", "mini rad-poison crossbow", "cloaking device", "revolver", "butcher's knife", "amplified vuvuzela", "power gloves", "signal jammer")
 
@@ -810,6 +824,7 @@ datum/pathogeneffects/malevolent/serious_paranoia/mild
 	desc = "The infected is suspicious of others, to the point where they might see others do traitorous things."
 	infect_type = INFECT_NONE
 	rarity = RARITY_UNCOMMON
+	danger_score = 3
 
 	may_react_to()
 		return "The pathogen appears to be wilder than usual, perhaps sedatives or psychoactive substances might affect its behaviour."
@@ -888,6 +903,7 @@ datum/pathogeneffects/malevolent/teleportation
 	desc = "The infected exists in a twisted spacetime."
 	infect_type = INFECT_NONE
 	rarity = RARITY_RARE
+	danger_score = 7
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
@@ -940,6 +956,7 @@ datum/pathogeneffects/malevolent/gibbing
 	permeability_score = 0
 	spread = SPREAD_FACE | SPREAD_HANDS | SPREAD_AIR | SPREAD_BODY
 	infection_coefficient = 4
+	danger_score = 15
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
@@ -989,6 +1006,7 @@ datum/pathogeneffects/malevolent/shakespeare
 	desc = "The infected has an urge to begin reciting shakespearean poetry."
 	infect_type = INFECT_NONE
 	rarity = RARITY_VERY_COMMON
+	danger_score = 0
 	var/static/list/shk = list("Expectation is the root of all heartache.",
 "A fool thinks himself to be wise, but a wise man knows himself to be a fool.",
 "Love all, trust a few, do wrong to none.",
@@ -1032,6 +1050,7 @@ datum/pathogeneffects/malevolent/fluent
 	spread = SPREAD_FACE
 	infect_message = "<span style=\"color:red\">A drop of saliva lands on your face.</span>"
 	rarity = RARITY_UNCOMMON
+	danger_score = 0
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		return
 
@@ -1060,6 +1079,7 @@ datum/pathogeneffects/malevolent/capacitor
 	desc = "The infected is involuntarily electrokinetic."
 	infect_type = INFECT_AREA_LARGE
 	rarity = RARITY_VERY_RARE
+	danger_score = 9
 	var/static/capacity = 1e7
 	proc/electrocute(var/mob/V as mob, var/shock_load)
 		V.shock(src, shock_load, "chest", 1, 0.5)
@@ -1359,6 +1379,7 @@ datum/pathogeneffects/malevolent/capacitor
 
 datum/pathogeneffects/malevolent/capacitor/unlimited
 	name = "Unlimited Capacitor"
+	danger_score = 6
 
 	load_check(var/mob/M as mob, var/datum/pathogen/origin)
 		return null
@@ -1372,6 +1393,7 @@ datum/pathogeneffects/malevolent/sunglass
 	desc = "The infected grew sunglass glands."
 	infect_type = INFECT_NONE
 	rarity = RARITY_UNCOMMON
+	danger_score = 0
 
 	proc/glasses(var/mob/living/carbon/human/M as mob)
 		M.show_message("<span style=\"color:blue\">[pick("You feel cooler!", "You find yourself wearing sunglasses.", "A pair of sunglasses grow onto your face.")]</span>")
@@ -1420,6 +1442,7 @@ datum/pathogeneffects/malevolent/liverdamage
 	desc = "The infected has an inflamed liver."
 	infect_type = INFECT_NONE
 	rarity = RARITY_UNCOMMON
+	danger_score = 2
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
@@ -1474,6 +1497,7 @@ datum/pathogeneffects/malevolent/fever
 	desc = "The body temperature of the infected individual slightly increases."
 	infect_type = INFECT_NONE
 	rarity = RARITY_COMMON
+	danger_score = 2
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -1511,6 +1535,7 @@ datum/pathogeneffects/malevolent/acutefever
 	desc = "The body temperature of the infected individual seriously increases and may spontaneously combust."
 	infect_type = INFECT_NONE
 	rarity = RARITY_RARE
+	danger_score = 8
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -1561,6 +1586,7 @@ datum/pathogeneffects/malevolent/ultimatefever
 	desc = "The body temperature of the infected individual seriously increases and may spontaneously combust. Or worse."
 	infect_type = INFECT_NONE
 	rarity = RARITY_VERY_RARE
+	danger_score = 15
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -1615,6 +1641,7 @@ datum/pathogeneffects/malevolent/chills
 	desc = "The infected feels the sensation of lowered body temperature."
 	infect_type = INFECT_NONE
 	rarity = RARITY_COMMON
+	danger_score = 2
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
@@ -1657,6 +1684,7 @@ datum/pathogeneffects/malevolent/seriouschills
 	desc = "The infected feels the sensation of seriously lowered body temperature."
 	infect_type = INFECT_NONE
 	rarity = RARITY_RARE
+	danger_score = 5
 
 	proc/create_icing(var/mob/M)
 		var/obj/decal/icefloor/I = unpool(/obj/decal/icefloor)
@@ -1729,6 +1757,7 @@ datum/pathogeneffects/malevolent/seriouschills/ultimate
 	desc = "The infected feels the sensation of seriously lowered body temperature. And might spontaneously become an ice statue."
 	infect_type = INFECT_NONE
 	rarity = RARITY_VERY_RARE
+	danger_score = 14
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -1791,6 +1820,7 @@ datum/pathogeneffects/malevolent/farts
 	infect_type = INFECT_AREA
 	spread = SPREAD_AIR
 	rarity = RARITY_VERY_COMMON
+	danger_score = 0
 
 	proc/fart(var/mob/M, var/datum/pathogen/origin)
 		M.emote("fart")
@@ -1809,6 +1839,7 @@ datum/pathogeneffects/malevolent/farts/smoke
 	name = "Smoke Farts"
 	desc = "The infected individual occasionally farts reagent smoke."
 	rarity = RARITY_RARE
+	danger_score = 0
 
 	fart(var/mob/M, var/datum/pathogen/origin)
 		..()
@@ -1834,6 +1865,7 @@ datum/pathogeneffects/malevolent/farts/plasma
 	name = "Plasma Farts"
 	desc = "The infected individual occasionally farts. Plasma."
 	rarity = RARITY_UNCOMMON
+	danger_score = 8
 
 	fart(var/mob/M, var/datum/pathogen/origin)
 		..()
@@ -1863,6 +1895,7 @@ datum/pathogeneffects/malevolent/farts/co2
 	name = "CO2 Farts"
 	desc = "The infected individual occasionally farts. Carbon dioxyde."
 	rarity = RARITY_RARE
+	danger_score = 7
 
 	fart(var/mob/M, var/datum/pathogen/origin)
 		..()
@@ -1892,6 +1925,7 @@ datum/pathogeneffects/malevolent/leprosy
 	name = "Leprosy"
 	desc = "The infected individual is losing limbs."
 	rarity = RARITY_VERY_RARE
+	danger_score = 12
 
 	disease_act(var/mob/living/carbon/human/M, var/datum/pathogen/origin)
 		if (origin.stage < 3 || !origin.symptomatic)
@@ -1917,6 +1951,7 @@ datum/pathogeneffects/malevolent/senility
 	desc = "Infection damages nerve cells in the host's brain."
 	rarity = RARITY_RARE
 	infect_type = INFECT_NONE
+	danger_score = 9
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
@@ -1956,6 +1991,7 @@ datum/pathogeneffects/malevolent/beesneeze
 	permeability_score = 25
 	spread = SPREAD_FACE | SPREAD_HANDS | SPREAD_AIR | SPREAD_BODY
 	infection_coefficient = 2
+	danger_score = 0
 
 	proc/sneeze(var/mob/M, var/datum/pathogen/origin)
 		if (!M || !origin)
@@ -2010,6 +2046,7 @@ datum/pathogeneffects/malevolent/mutation
 	desc = "The infected individual occasionally mutates wildly!"
 	infect_type = INFECT_NONE
 	rarity = RARITY_VERY_RARE
+	danger_score = 12
 
 	//multiply origin.stage by this number to get the percent probability of a mutation occurring per disease_act
 	//please keep it between 1 and 20, inclusive, if possible.
@@ -2058,6 +2095,7 @@ datum/pathogeneffects/malevolent/mutation/reinforced
 	mut_prob_mult = 3
 	chrom_prob = 100 //guaranteed chromosome application
 	chrom_types = list(/datum/dna_chromosome/anti_mutadone) //reinforcer chromosome
+	danger_score = 14
 
 	react_to(var/R, var/zoom)
 		if (R == "mutadone")
@@ -2077,6 +2115,7 @@ datum/pathogeneffects/malevolent/mutation/beneficial
 	chrom_prob = 100 //guranteed chromosome application
 	chrom_types = list(/datum/dna_chromosome) //stabilizer, no instability caused
 	beneficial = 1
+	danger_score = -15
 
 	react_to(var/R, var/zoom)
 		if (R == "mutadone")
@@ -2090,6 +2129,7 @@ datum/pathogeneffects/malevolent/radiation
 	desc = "Infection irradiates the host's cells."
 	infect_type = INFECT_NONE
 	rarity = RARITY_RARE
+	danger_score = 12
 
 	disease_act(var/mob/M as mob, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -2132,6 +2172,7 @@ datum/pathogeneffects/malevolent/snaps
 	spread = SPREAD_FACE | SPREAD_HANDS | SPREAD_AIR | SPREAD_BODY
 	infect_message = "<span style=\"color:red\">That's a pretty catchy groove...</span>" //you might even say it's infectious
 	rarity = RARITY_COMMON
+	danger_score = 2
 
 	proc/snap(var/mob/M, var/datum/pathogen/origin)
 		M.emote("snap")
@@ -2157,6 +2198,7 @@ datum/pathogeneffects/malevolent/snaps/jazz
 	name = "Jazz Snaps"
 	desc = "The infection forces its host's fingers to occasionally snap. Also, it transforms the host into a jazz musician."
 	rarity = RARITY_RARE
+	danger_score = 7
 
 	proc/jazz(var/mob/living/carbon/human/H as mob)
 		H.show_message("<span style=\"color:blue\">[pick("You feel cooler!", "You feel smooth and laid-back!", "You feel jazzy!", "A sudden soulfulness fills your spirit!")]</span>")
@@ -2224,7 +2266,7 @@ datum/pathogeneffects/malevolent/snaps/wild
 	name = "Wild Snaps"
 	desc = "The infection forces its host's fingers to constantly and painfully snap. Highly contagious."
 	rarity = RARITY_VERY_RARE
-
+	danger_score = 13
 
 	proc/snap_arm(var/mob/M, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
@@ -2279,6 +2321,7 @@ datum/pathogeneffects/malevolent/detonation
 	name = "Necrotic Detonation"
 	desc = "The pathogen will cause you to violently explode upon death."
 	rarity = RARITY_VERY_RARE
+	danger_score = 8
 
 	may_react_to()
 		return "Some of the pathogen's dead cells seem to remain active."

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -1903,8 +1903,6 @@ datum/pathogeneffects/malevolent/leprosy
 							SPAWN_DBG(rand(150, 200))
 								if (limb.remove_stage == 2)
 									limb.remove(0)
-	may_react_to()
-		return "The pathogen appears to be rapidly breaking down certain materials around it."
 
 datum/pathogeneffects/malevolent/senility
 	name = "Senility"
@@ -1941,8 +1939,6 @@ datum/pathogeneffects/malevolent/senility
 					M.show_message("<span style=\"color:red\">You completely forget what you were doing.</span>")
 					M.drop_item()
 					M.take_brain_damage(4)
-	may_react_to()
-		return "The pathogen appears to have a gland that may affect neural functions."
 
 datum/pathogeneffects/malevolent/beesneeze
 	name = "Projectile Bee Egg Sneezing"

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -395,7 +395,7 @@ datum/pathogeneffects/malevolent/gasping
 	may_react_to()
 		return "The pathogen appears to create bubbles of vacuum around its affected area."
 
-/*datum/pathogeneffects/malevolent/moaning
+datum/pathogeneffects/malevolent/moaning
 	name = "Moaning"
 	desc = "This is literally pointless."
 	infect_type = INFECT_NONE
@@ -457,7 +457,7 @@ datum/pathogeneffects/malevolent/hiccups
 					M:emote("hiccup")
 
 	may_react_to()
-		return "The pathogen appears to be violently... hiccuping?"*/
+		return "The pathogen appears to be violently... hiccuping?"
 
 datum/pathogeneffects/malevolent/shivering
 	name = "Shivering"

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -16,6 +16,8 @@ datum/pathogeneffects
 	var/rarity = RARITY_ABSTRACT
 	var/infect_message = null
 
+	var/beneficial = 0
+
 	// This is a list of mutual exclusive symptom TYPES.
 	// If this contains any symptoms, none of these symptoms will be picked upon mutation or initial raffle.
 	// Mutexes cut the ENTIRE object tree - for example, if symptoms a/b, a/c and a/d all exist, then mutexing
@@ -2073,6 +2075,7 @@ datum/pathogeneffects/malevolent/mutation/beneficial
 	mutation_type = "good"
 	chrom_prob = 100 //guranteed chromosome application
 	chrom_types = list(/datum/dna_chromosome) //stabilizer, no instability caused
+	beneficial = 1
 
 	react_to(var/R, var/zoom)
 		if (R == "mutadone")

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -126,6 +126,11 @@ datum/pathogeneffects
 	proc/ondeath(var/mob/M as mob, var/datum/pathogen/origin)
 		return
 
+	// ondeath(mob, datum/pathogen) : void
+	// OVERRIDE: Overriding this is situational. Mainly for cleanup.
+	proc/oncured(var/mob/M as mob, var/datum/pathogen/origin)
+		return
+
 	// End of events: please do not add any event definitions outside this block.
 	// ====
 

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -1875,6 +1875,7 @@ datum/pathogeneffects/malevolent/farts/co2
 		if (T)
 			T.assume_air(gas)
 
+	disease_act(var/mob/M, var/datum/pathogen/origin)
 		if (!origin.symptomatic)
 			return
 		..()

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -744,7 +744,7 @@ Only trained personnel should operate station systems. Follow all procedures car
 /obj/item/paper/cdc_pamphlet
 	name = "So you've contracted a pathogen!"
 	icon_state = "paper"
-	info = {"<center><h2>How to send a pathogen sample</h2></center>
+	info = {"<center><h2>So you've contracted a pathogen!</h2></center>
 	Hello, dear customer!<hr>
 	Pathogens can be scary! But you can rest easy knowing that your health is in safe hands now that you have contacted the CDC. Simply place a pathogen sample into the biohazard crate and send it back to us and we will have you cured in no time!<hr>
 	<h3>How to send a pathogen sample</h3><hr>

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -741,6 +741,24 @@ Only trained personnel should operate station systems. Follow all procedures car
 	- B <br>
 	"}
 
+/obj/item/paper/cdc_pamphlet
+	name = "So you've contracted a pathogen!"
+	icon_state = "paper"
+	info = {"<center><h2>How to send a pathogen sample</h2></center>
+	Hello, dear customer!<hr>
+	Pathogens can be scary! But you can rest easy knowing that your health is in safe hands now that you have contacted the CDC. Simply place a pathogen sample into the biohazard crate and send it back to us and we will have you cured in no time!<hr>
+	<h3>How to send a pathogen sample</h3><hr>
+	<ul style='list-style-type:disc'>
+		<li>1) Fill a reagent container with a blood sample from a person afflicted with the pathogen you are seeking to cure. (For instance, you could use the syringe we sent you!)</li>
+		<li>2) Deposit reagent container into the received biohazard crate and close it.</li>
+		<li>3) Send the biohazard crate back to us.</li>
+		<li>4) As soon as we receive your sample, you can contact us using your Quartermaster's Console to ask us to start analyzing it.</li>
+		<li>5) Once we are done analyzing your sample, we will offer to sell you cures. Buying a pack of multiple cures at a time will be cheaper for you!</li>
+	</ul>
+	We hope that you have found this pamphlet enlightening and we hope to receive your sample soon!<hr>
+	Remember, only you can prevent deadly pathogens!
+	"}
+
 /obj/item/paper/fortune
 	name = "fortune"
 	info = {"<center>YOUR FORTUNE</center>"}
@@ -1279,3 +1297,4 @@ WHO DID THIS */
     <b>PRIVATE ESOTERIC RESEARCH STATION - EUROPA:</b> CLEAN UP RESEARCH FACILITY AND ATTACHED SUBMERSIBLE VEHICLES, MODERATE CASUALTIES.<br>
     <b>SPECIAL INSTRUCTIONS</b> WILL PAY DOUBLE IF SUB-BASEMENT 3 IS CLEARED OF ALL RESEARCH SPECIMENS AND SUBJECTS, ALL SPECIMENS AND SUBJECTS ARE EFFECTIVELY BRAINDEAD, SUPPLY OWN MEANS OF EXECUTION OF SUBJECTS.<br>
     <b>STATUS:</b> BEING CLEANED"}
+

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -100,7 +100,9 @@
 
 	cdc
 		name = "CDC pathogen sample crate"
-		desc = "A crate for sending pathogen or blood samples to the CDC for analysis."
+		desc = "A crate for sending pathogen or blood samples to the CDC for analysis."	
+		spawn_contents = list(/obj/item/reagent_containers/syringe,
+		/obj/item/paper/cdc_pamphlet)
 
 /obj/storage/crate/freezer/milk
 	spawn_contents = list(/obj/item/reagent_containers/food/drinks/milk = 10, \

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -110,6 +110,10 @@
 
 		if (H.pathogens.len)
 			pathogen_data = "<span style='color:red'>Scans indicate the presence of [H.pathogens.len > 1 ? "[H.pathogens.len] " : null]pathogenic bodies.</span>"
+			// Realistically people will very, very rarely be affected by more than one pathogen, so I think it's fine to just list the stages.
+			for (var/uid in H.pathogens) 
+				var/datum/pathogen/P = H.pathogens[uid]
+				pathogen_data += "<br><span style='color:red'>The pathogen seems to be in Stage [P.stage].</span>"
 			var/list/therapy = list()
 			var/remissive = 0
 			for (var/uid in H.pathogens)

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -113,7 +113,7 @@
 			// Realistically people will very, very rarely be affected by more than one pathogen, so I think it's fine to just list the stages.
 			for (var/uid in H.pathogens) 
 				var/datum/pathogen/P = H.pathogens[uid]
-				pathogen_data += "<br><span style='color:red'>The pathogen seems to be in Stage [P.stage].</span>"
+				pathogen_data += "<br>&emsp;<span style='color:red'>[P.name]: Stage [P.stage], Predicted Threat Level: [P.danger_score()]</span>"
 			var/list/therapy = list()
 			var/remissive = 0
 			for (var/uid in H.pathogens)

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -2,7 +2,6 @@ slurm - Host
 gibbed - Host
 stuntwaffle - Inactive
 wirewraith - Host
-zjdtmkhzt - Host
 
 pantaloons - Inactive
 keelin - Coder

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -2,6 +2,7 @@ slurm - Host
 gibbed - Host
 stuntwaffle - Inactive
 wirewraith - Host
+zjdtmkhzt - Host
 
 pantaloons - Inactive
 keelin - Coder

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -797,6 +797,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\modules\medical\genetics\bioEffects\powers.dm"
 #include "code\modules\medical\genetics\bioEffects\speech.dm"
 #include "code\modules\medical\genetics\bioEffects\useless.dm"
+#include "code\modules\medical\pathology\_pathogen_constants.dm"
 #include "code\modules\medical\pathology\pathogen.dm"
 #include "code\modules\medical\pathology\pathogen_ailments.dm"
 #include "code\modules\medical\pathology\pathogen_benevolent.dm"


### PR DESCRIPTION
Adds two new Pathology Symptoms:
- Necrotic Resurrection(T5): Resurrects you when you die with it at Stage 5, though your body will start rotting and you will still be heavily damaged. The pathogen will also begin curing itself after resurrecting you once and make you immune to future infections from it, so you can't use it more than once.
- Necrotic Detonation(T5): Does nothing until you die. Then you explode. (The numbers might need some fiddling, depending on feedback from people ingame, but I think I made it fair enough.)

Fixes:
- Fixed the irradiation module literally never working
- Fixed a pathogen never being able to advance through stages again if it was suppressed once (even after the suppression ends)

Changes:
- Added GUI elements to the DNA Analyzer in the Pathogen Manipulator that make it so you can see if a stable symptom you are analyzing is good or bad and how many good or bad followers a transient symptom has. This should make it easier for people to find good symptoms, if they wish to (and of course, the inverse as well).
- Added a free syringe and educational pamphlet to the CDC crates, describing how to send a pathogen sample back.

Internal Changes:
- Added an ondeath event for symptoms that triggers when the afflicted dies
- Added a disease_act_dead proc for symptoms, it works practically identically to the existing disease_act proc, except this one is only called on afflicted that are dead, rather than those that are alive.
- Moved the Infection-Type constants from pathogen_symptoms.dm to a separate file _pathogen_constants.dm, so they can now be used in pathogen_benevolent.dm as well.

This is my first PR, and my first time coding Byond, so I hope I did not make any egregious errors. If there are questions or balance concerns, feel free to message me on discord. (✿◕‿◕)