### PR TITLE
PTL Payout Fix

### DIFF
--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -173,7 +173,7 @@
 	if (round(output) == 0)
 		return FALSE
 
-	var/output_mw = output * 1e6
+	var/output_mw = output / 1e6
 
 	#define BUX_PER_SEC_CAP 5000 //at inf power, generate 5000$/tick, also max amt to drain/tick
 	#define ACCEL_FACTOR 69 //our acceleration factor towards cap


### PR DESCRIPTION
The code currently always gives the max payout of $5,000 credits per tick. It was intended to scale.
It's broken because of a multiplication, where there should be a division.
Tested, the fix, now works as originally intended.
This WILL nerf the payout.
The little bit of Discord opinion gathering that I did seemed to think the current payout's too high anyways.
![Intended Credits per Tick](https://user-images.githubusercontent.com/9563541/75130818-1d463180-5685-11ea-861b-5df823da3e37.png)
