### PR TITLE
Adds decorative plant pots!

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -878,6 +878,7 @@
 		product_list += new/datum/data/vending_product(/obj/item/plantanalyzer, 5)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/glass/compostbag, 5)
 		product_list += new/datum/data/vending_product(/obj/item/saw, 3)
+		product_list += new/datum/data/vending_product(/obj/item/gardentrowel, 5)
 		product_list += new/datum/data/vending_product(/obj/item/satchel/hydro, 10)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/glass/beaker, 10)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/glass/bottle/weedkiller, 10)
@@ -886,6 +887,7 @@
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/glass/bottle/topcrop, 5)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/glass/bottle/powerplant, 5)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/glass/bottle/fruitful, 5)
+		product_list += new/datum/data/vending_product(/obj/decorative_pot, 5)
 
 		product_list += new/datum/data/vending_product(/obj/item/seedplanter/hidden, 1, hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/seed/grass, rand(3, 6), hidden=1)

--- a/code/obj/item/decorative_pot.dm
+++ b/code/obj/item/decorative_pot.dm
@@ -12,10 +12,12 @@
     attackby(obj/item/weapon as obj,mob/user as mob)
         if(istype(weapon,/obj/item/wrench) || istype(weapon,/obj/item/screwdriver))
             if(!src.anchored)
-                user.visible_message("<b>[user]</b> wrenches the [src] in place!")
+                user.visible_message("<b>[user]</b> secures the [src] to the floor!")
+                playsound(src.loc, "sound/items/Screwdriver.ogg", 100, 1)
                 src.anchored = 1
             else
                 user.visible_message("<b>[user]</b> unbolts the [src] from the floor!")
+                playsound(src.loc, "sound/items/Screwdriver.ogg", 100, 1)
                 src.anchored = 0
             return
         else if(istype(weapon,/obj/item/gardentrowel))

--- a/code/obj/item/decorative_pot.dm
+++ b/code/obj/item/decorative_pot.dm
@@ -1,6 +1,8 @@
 /obj/decorative_pot
+    name = "plant pot"
+    desc = "A decorative plant pot, sans the Hydroponic Tray's fancy hypergrowth tech."
     icon = 'icons/obj/hydroponics/hydromisc.dmi'
-    icon_state = 'plantpot'
+    icon_state = "plantpot"
 
 	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 		return 0

--- a/code/obj/item/decorative_pot.dm
+++ b/code/obj/item/decorative_pot.dm
@@ -4,23 +4,22 @@
     icon = 'icons/obj/hydroponics/hydromisc.dmi'
     icon_state = "plantpot"
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-		return 0
-
-	attackby(obj/item/weapon as obj,mob/user as mob)
-		if(istype(weapon,/obj/item/wrench) || istype(weapon,/obj/item/screwdriver))
-			if(!src.anchored)
-				user.visible_message("<b>[user]</b> wrenches the [src] in place!")
-				src.anchored = 1
-			else
-				user.visible_message("<b>[user]</b> unbolts the [src] from the floor!")
-				src.anchored = 0
+    CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+        return 0
+    attackby(obj/item/weapon as obj,mob/user as mob)
+        if(istype(weapon,/obj/item/wrench) || istype(weapon,/obj/item/screwdriver))
+            if(!src.anchored)
+                user.visible_message("<b>[user]</b> wrenches the [src] in place!")
+                src.anchored = 1
+            else
+                user.visible_message("<b>[user]</b> unbolts the [src] from the floor!")
+                src.anchored = 0
             return
         else if(istype(weapon,/obj/item/gardentrowel))
             var/obj/item/gardentrowel/t = weapon
             src.UpdateOverlays(t.plantyboi,"plant")
-            src.plantyboi = null
+            t.plantyboi = null
             src.icon_state = "trowel"
             return
-		else
-			..()
+        else
+            ..()

--- a/code/obj/item/decorative_pot.dm
+++ b/code/obj/item/decorative_pot.dm
@@ -3,7 +3,10 @@
     desc = "A decorative plant pot, sans the Hydroponic Tray's fancy hypergrowth tech."
     icon = 'icons/obj/hydroponics/hydromisc.dmi'
     icon_state = "plantpot"
-
+    anchored = 0
+    density = 1
+    mats = 2
+    
     CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
         return 0
     attackby(obj/item/weapon as obj,mob/user as mob)

--- a/code/obj/item/decorative_pot.dm
+++ b/code/obj/item/decorative_pot.dm
@@ -1,0 +1,24 @@
+/obj/decorative_pot
+    icon = 'icons/obj/hydroponics/hydromisc.dmi'
+    icon_state = 'plantpot'
+
+	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+		return 0
+
+	attackby(obj/item/weapon as obj,mob/user as mob)
+		if(istype(weapon,/obj/item/wrench) || istype(weapon,/obj/item/screwdriver))
+			if(!src.anchored)
+				user.visible_message("<b>[user]</b> wrenches the [src] in place!")
+				src.anchored = 1
+			else
+				user.visible_message("<b>[user]</b> unbolts the [src] from the floor!")
+				src.anchored = 0
+            return
+        else if(istype(weapon,/obj/item/gardentrowel))
+            var/obj/item/gardentrowel/t = weapon
+            src.UpdateOverlays(t.plantyboi,"plant")
+            src.plantyboi = null
+            src.icon_state = "trowel"
+            return
+		else
+			..()

--- a/code/obj/item/decorative_pot.dm
+++ b/code/obj/item/decorative_pot.dm
@@ -16,10 +16,12 @@
                 src.anchored = 0
             return
         else if(istype(weapon,/obj/item/gardentrowel))
+            if(!plantyboi)
+                return
             var/obj/item/gardentrowel/t = weapon
             src.UpdateOverlays(t.plantyboi,"plant")
             t.plantyboi = null
-            src.icon_state = "trowel"
+            t.icon_state = "trowel"
             return
         else
             ..()

--- a/code/obj/item/decorative_pot.dm
+++ b/code/obj/item/decorative_pot.dm
@@ -16,9 +16,9 @@
                 src.anchored = 0
             return
         else if(istype(weapon,/obj/item/gardentrowel))
-            if(!plantyboi)
-                return
             var/obj/item/gardentrowel/t = weapon
+            if(!t.plantyboi)
+                return
             src.UpdateOverlays(t.plantyboi,"plant")
             t.plantyboi = null
             t.icon_state = "trowel"

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -332,6 +332,7 @@
 				var/datum/plant/p = pot.current
 				if(pot.GetOverlayImage("plant"))
 					plantyboi = pot.GetOverlayImage("plant")
+					plantyboi.pixel_x = 2
 					src.icon_state = "trowel_full"
 				else
 					return

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -302,7 +302,7 @@
 ///////////////////////////////////// Garden Trowel ///////////////////////////////////////////////	
 
 /obj/item/gardentrowel
-	name = "Garden Trowel"
+	name = "garden trowel"
 	desc = "A tool to uproot plants and transfer them to decorative pots"
 	icon = 'icons/obj/hydroponics/hydromisc.dmi'
 	inhand_image_icon = 'icons/mob/inhand/tools/screwdriver.dmi'
@@ -323,7 +323,7 @@
 
 	module_research = list("tools" = 4, "metals" = 1)
 	rand_pos = 1
-	var/icon/plantyboi
+	var/image/plantyboi
 
 	afterattack(obj/target as obj, mob/user as mob)
 		if(istype(target, /obj/machinery/plantpot))

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -6,6 +6,7 @@
 // - Watering can
 // - Compost bag
 // - Plant formulas
+// - Garden Trowel
 
 //////////////////////////////////////////////// Chainsaw ////////////////////////////////////
 
@@ -297,6 +298,48 @@
 /obj/item/seedplanter/hidden
 	desc = "This is supposed to be a cyborg part. You're not quite sure what it's doing here."
 
+
+///////////////////////////////////// Garden Trowel ///////////////////////////////////////////////	
+
+/obj/item/gardentrowel
+	name = "Garden Trowel"
+	desc = "A tool to uproot plants and transfer them to decorative pots"
+	icon = 'icons/obj/hydroponics/hydromisc.dmi'
+	inhand_image_icon = 'icons/mob/inhand/tools/screwdriver.dmi'
+	icon_state = "trowel_empty"
+
+	flags = FPRINT | TABLEPASS | ONBELT
+	w_class = 1.0
+
+	force = 5.0
+	throwforce = 5.0
+	throw_speed = 3
+	throw_range = 5
+	stamina_damage = 10
+	stamina_cost = 10
+	stamina_crit_chance = 30
+	hit_type = DAMAGE_STAB
+	hitsound = 'sound/impact_sounds/Flesh_Stab_1.ogg'
+
+	module_research = list("tools" = 4, "metals" = 1)
+	rand_pos = 1
+	var/icon/plantyboi
+
+	afterattack(obj/target as obj, mob/user as mob)
+		if(istype(target, /obj/machinery/plantpot))
+			var/obj/machinery/plantpot/pot = target
+			if(pot.current)
+				var/datum/plant/p = pot.current
+				if(pot.GetOverlayImage("plant"))
+					plantyboi = pot.GetOverlayImage("plant")
+				else
+					return
+				if(p.growthmode == "weed")
+					user.visible_message("<b>[user]</b> tries to uproot the [p.name], but it's roots hold firmly to the [pot]!","<span style=\"color:red\">The [p.name] is too strong for you traveller...</span>")
+					return
+				pot.HYPdestroyplant()
+
+		//check if target is a plant pot to paste in the cosmetic plant overlay
 ///////////////////////////////////// Watering can ///////////////////////////////////////////////
 
 /obj/item/reagent_containers/glass/wateringcan/

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -323,7 +323,7 @@
 
 	module_research = list("tools" = 4, "metals" = 1)
 	rand_pos = 1
-	var/image/plantyboi
+	var/icon/plantyboi
 
 	afterattack(obj/target as obj, mob/user as mob)
 		if(istype(target, /obj/machinery/plantpot))

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -306,7 +306,7 @@
 	desc = "A tool to uproot plants and transfer them to decorative pots"
 	icon = 'icons/obj/hydroponics/hydromisc.dmi'
 	inhand_image_icon = 'icons/mob/inhand/tools/screwdriver.dmi'
-	icon_state = "trowel_empty"
+	icon_state = "trowel"
 
 	flags = FPRINT | TABLEPASS | ONBELT
 	w_class = 1.0
@@ -332,6 +332,7 @@
 				var/datum/plant/p = pot.current
 				if(pot.GetOverlayImage("plant"))
 					plantyboi = pot.GetOverlayImage("plant")
+					src.icon_state = "trowel_full"
 				else
 					return
 				if(p.growthmode == "weed")

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -323,7 +323,7 @@
 
 	module_research = list("tools" = 4, "metals" = 1)
 	rand_pos = 1
-	var/icon/plantyboi
+	var/image/plantyboi
 
 	afterattack(obj/target as obj, mob/user as mob)
 		if(istype(target, /obj/machinery/plantpot))

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1061,6 +1061,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\obj\item\coin.dm"
 #include "code\obj\item\dartboard.dm"
 #include "code\obj\item\decoration.dm"
+#include "code\obj\item\decorative_pot.dm"
 #include "code\obj\item\deployable_turret.dm"
 #include "code\obj\item\dice.dm"
 #include "code\obj\item\fitness.dm"


### PR DESCRIPTION
This patch adds a garden trowel and a decorative plant pot to the game, available from the GardenGear vending machine. Grab a trowel and pot from the vendor, plant a seed in a Hydroponics Tray, wait for it to reach the desired growth stage, then whack the plant with the trowel to uproot it. Place it in the decorative plant pot and go!

Functionally, the trowel kills the target plant and copies it's current sprite, then applies that sprite to the decorative plant pot. The plants are purposefully non-functional, forever frozen in whatever status they were in when uprooted. Frighten your friends and family with false lasher vines! Spice up your after-school rave with some perfectly legal fake rainbow weed! The possiblities are endless.

Sprites will be in the ss13.co patch thread.